### PR TITLE
Fix issues in the company search form

### DIFF
--- a/app/Controller/FormController.php
+++ b/app/Controller/FormController.php
@@ -15,6 +15,13 @@ class FormController extends Controller
     {
         $matcher = new CompanyMatcher($this->db());
 
+        $matcher->match(
+            $_POST['postcode'],
+            $_POST['bedrooms'],
+            $_POST['survey_type'],
+            $this->getMaxMatchedCompanies()
+        );
+
         $this->render('results.twig', [
             'matchedCompanies'  => $matchedCompanies,
         ]);

--- a/app/Controller/FormController.php
+++ b/app/Controller/FormController.php
@@ -13,6 +13,14 @@ class FormController extends Controller
 
     public function submit()
     {
+        $errors = $this->validateRequest();
+        if (!empty($errors)) {
+            $this->render('form.twig', [
+                'errors' => $errors,
+            ]);
+            return;
+        }
+
         $matcher = new CompanyMatcher($this->db());
 
         $matcher->match(
@@ -27,6 +35,30 @@ class FormController extends Controller
         $this->render('results.twig', [
             'matchedCompanies'  => $matcher->results(),
         ]);
+    }
+
+    private function validateRequest(): array
+    {
+        $errors = [];
+
+        if (
+            !isset($_POST['postcode']) ||
+            empty($_POST['postcode']) ||
+            !preg_match('/^[A-Z]{1,2}[A-Z0-9 ]+$/i', $_POST['postcode'])
+        ) {
+            $errors[] = 'A valid postcode is required';
+        }
+
+        if (!isset($_POST['bedrooms']) || !is_numeric($_POST['bedrooms'])) {
+            $errors[] = 'A valid number of bedrooms is required';
+        }
+
+        $survey_types = ['homebuyer', 'valuation', 'building'];
+        if (!isset($_POST['survey_type']) || !in_array($_POST['survey_type'], $survey_types)) {
+            $errors[] = 'A valid survey type is required';
+        }
+
+        return $errors;
     }
 
     private function getMaxMatchedCompanies(): int

--- a/app/Controller/FormController.php
+++ b/app/Controller/FormController.php
@@ -22,6 +22,8 @@ class FormController extends Controller
             $this->getMaxMatchedCompanies()
         );
 
+        $matcher->deductCredits();
+
         $this->render('results.twig', [
             'matchedCompanies'  => $matchedCompanies,
         ]);

--- a/app/Controller/FormController.php
+++ b/app/Controller/FormController.php
@@ -19,4 +19,15 @@ class FormController extends Controller
             'matchedCompanies'  => $matchedCompanies,
         ]);
     }
+
+    private function getMaxMatchedCompanies(): int
+    {
+        $maxMatchedCompanies = (int) $_ENV['MAX_MATCHED_COMPANIES'];
+
+        if ($maxMatchedCompanies < 1) {
+            $maxMatchedCompanies = 3;
+        }
+
+        return $maxMatchedCompanies;
+    }
 }

--- a/app/Controller/FormController.php
+++ b/app/Controller/FormController.php
@@ -4,7 +4,7 @@ namespace App\Controller;
 
 use App\Service\CompanyMatcher;
 
-class FormController
+class FormController extends Controller
 {
     public function index()
     {

--- a/app/Controller/FormController.php
+++ b/app/Controller/FormController.php
@@ -25,7 +25,7 @@ class FormController extends Controller
         $matcher->deductCredits();
 
         $this->render('results.twig', [
-            'matchedCompanies'  => $matchedCompanies,
+            'matchedCompanies'  => $matcher->results(),
         ]);
     }
 

--- a/app/Service/CompanyMatcher.php
+++ b/app/Service/CompanyMatcher.php
@@ -28,7 +28,8 @@ class CompanyMatcher
                 `companies`.`description`,
                 `companies`.`email`,
                 `companies`.`phone`,
-                `companies`.`website`
+                `companies`.`website`,
+                RAND() as `random_order`
             FROM `company_matching_settings`
             INNER JOIN `companies`
             ON `company_matching_settings`.`company_id` = `companies`.`id`
@@ -37,6 +38,7 @@ class CompanyMatcher
             AND `company_matching_settings`.`type` = :survey_type
             AND `companies`.`credits` > 0
             AND `companies`.`active` = 1
+            ORDER BY `random_order`
             LIMIT :count'
         );
 

--- a/app/Service/CompanyMatcher.php
+++ b/app/Service/CompanyMatcher.php
@@ -2,24 +2,57 @@
 
 namespace App\Service;
 
+use PDO;
+
 class CompanyMatcher
 {
     private $db;
     private $matches = [];
 
-    public function __construct(\PDO $db) 
+    public function __construct(\PDO $db)
     {
         $this->db = $db;
     }
 
-    public function match()
+    public function match(string $postcode, int $bedrooms, string $surveyType, int $count = 3)
     {
-        
+        $postcode = $this->getPostcodePrefix($postcode);
+
+        $postcode = "%\"$postcode\"%";
+        $bedrooms = "%\"$bedrooms\"%";
+
+        $query = $this->db->prepare(
+            'SELECT
+                `companies`.`id`,
+                `companies`.`name`,
+                `companies`.`description`,
+                `companies`.`email`,
+                `companies`.`phone`,
+                `companies`.`website`
+            FROM `company_matching_settings`
+            INNER JOIN `companies`
+            ON `company_matching_settings`.`company_id` = `companies`.`id`
+            WHERE `company_matching_settings`.`postcodes` LIKE :postcode
+            AND `company_matching_settings`.`bedrooms` LIKE :bedrooms
+            AND `company_matching_settings`.`type` = :survey_type
+            AND `companies`.`credits` > 0
+            AND `companies`.`active` = 1
+            LIMIT :count'
+        );
+
+        $query->bindParam(':postcode', $postcode);
+        $query->bindParam(':bedrooms', $bedrooms);
+        $query->bindParam(':survey_type', $surveyType);
+        $query->bindParam(':count', $count, PDO::PARAM_INT);
+
+        $query->execute();
+
+        $this->matches = $query->fetchAll(PDO::FETCH_ASSOC);
     }
 
     public function pick(int $count)
     {
-        
+
     }
 
     public function results(): array
@@ -29,7 +62,7 @@ class CompanyMatcher
 
     public function deductCredits()
     {
-        
+
     }
 
     private function getPostcodePrefix(string $postcode): string

--- a/app/Service/CompanyMatcher.php
+++ b/app/Service/CompanyMatcher.php
@@ -31,4 +31,15 @@ class CompanyMatcher
     {
         
     }
+
+    private function getPostcodePrefix(string $postcode): string
+    {
+        preg_match(
+            '/^([A-Z]{1,2})/',
+            strtoupper($postcode),
+            $matches
+        );
+
+        return isset($matches[1]) ? $matches[1] : '';
+    }
 }

--- a/app/Service/CompanyMatcher.php
+++ b/app/Service/CompanyMatcher.php
@@ -55,9 +55,20 @@ class CompanyMatcher
         return $this->matches;
     }
 
-    public function deductCredits()
+    public function deductCredits(): void
     {
+        $companyIds = array_column($this->matches, 'id');
 
+        $query = $this->db->prepare(
+            sprintf(
+                'UPDATE `companies`
+                SET `credits` = `credits` - 1
+                WHERE `id` IN (%s)',
+                implode(',', array_fill(0, count($companyIds), '?'))
+            )
+        );
+
+        $query->execute($companyIds);
     }
 
     private function getPostcodePrefix(string $postcode): string

--- a/app/Service/CompanyMatcher.php
+++ b/app/Service/CompanyMatcher.php
@@ -50,11 +50,6 @@ class CompanyMatcher
         $this->matches = $query->fetchAll(PDO::FETCH_ASSOC);
     }
 
-    public function pick(int $count)
-    {
-
-    }
-
     public function results(): array
     {
         return $this->matches;

--- a/app/routes.php
+++ b/app/routes.php
@@ -4,7 +4,11 @@ return [
     '/form' => [
         [
             'type'      => 'GET',
-            'handler'   => 'FormController@index',   
-        ],       
+            'handler'   => 'FormController@index',
+        ],
+        [
+            'type'      => 'POST',
+            'handler'   => 'FormController@submit',
+        ],
     ]
 ];

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,625 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "38d2bf091399a8ebd793dfb48bdf40f6",
+    "packages": [
+        {
+            "name": "graham-campbell/result-type",
+            "version": "v1.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/GrahamCampbell/Result-Type.git",
+                "reference": "fbd48bce38f73f8a4ec8583362e732e4095e5862"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/GrahamCampbell/Result-Type/zipball/fbd48bce38f73f8a4ec8583362e732e4095e5862",
+                "reference": "fbd48bce38f73f8a4ec8583362e732e4095e5862",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5 || ^8.0",
+                "phpoption/phpoption": "^1.9.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.5.34 || ^9.6.13 || ^10.4.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "GrahamCampbell\\ResultType\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                }
+            ],
+            "description": "An Implementation Of The Result Type",
+            "keywords": [
+                "Graham Campbell",
+                "GrahamCampbell",
+                "Result Type",
+                "Result-Type",
+                "result"
+            ],
+            "support": {
+                "issues": "https://github.com/GrahamCampbell/Result-Type/issues",
+                "source": "https://github.com/GrahamCampbell/Result-Type/tree/v1.1.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/graham-campbell/result-type",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-11-12T22:16:48+00:00"
+        },
+        {
+            "name": "phpoption/phpoption",
+            "version": "1.9.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/schmittjoh/php-option.git",
+                "reference": "80735db690fe4fc5c76dfa7f9b770634285fa820"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/schmittjoh/php-option/zipball/80735db690fe4fc5c76dfa7f9b770634285fa820",
+                "reference": "80735db690fe4fc5c76dfa7f9b770634285fa820",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5 || ^8.0"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.8.2",
+                "phpunit/phpunit": "^8.5.34 || ^9.6.13 || ^10.4.2"
+            },
+            "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": true
+                },
+                "branch-alias": {
+                    "dev-master": "1.9-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpOption\\": "src/PhpOption/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Johannes M. Schmitt",
+                    "email": "schmittjoh@gmail.com",
+                    "homepage": "https://github.com/schmittjoh"
+                },
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                }
+            ],
+            "description": "Option Type for PHP",
+            "keywords": [
+                "language",
+                "option",
+                "php",
+                "type"
+            ],
+            "support": {
+                "issues": "https://github.com/schmittjoh/php-option/issues",
+                "source": "https://github.com/schmittjoh/php-option/tree/1.9.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpoption/phpoption",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-11-12T21:59:55+00:00"
+        },
+        {
+            "name": "symfony/deprecation-contracts",
+            "version": "v2.5.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/deprecation-contracts.git",
+                "reference": "80d075412b557d41002320b96a096ca65aa2c98d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/80d075412b557d41002320b96a096ca65aa2c98d",
+                "reference": "80d075412b557d41002320b96a096ca65aa2c98d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "2.5-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "function.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A generic function and convention to trigger deprecation notices",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v2.5.3"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-01-24T14:02:46+00:00"
+        },
+        {
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.29.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "ef4d7e442ca910c4764bce785146269b30cb5fc4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/ef4d7e442ca910c4764bce785146269b30cb5fc4",
+                "reference": "ef4d7e442ca910c4764bce785146269b30cb5fc4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "provide": {
+                "ext-ctype": "*"
+            },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.29.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-01-29T20:11:03+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.29.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "9773676c8a1bb1f8d4340a62efe641cf76eda7ec"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/9773676c8a1bb1f8d4340a62efe641cf76eda7ec",
+                "reference": "9773676c8a1bb1f8d4340a62efe641cf76eda7ec",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "provide": {
+                "ext-mbstring": "*"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.29.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-01-29T20:11:03+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php80",
+            "version": "v1.29.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php80.git",
+                "reference": "87b68208d5c1188808dd7839ee1e6c8ec3b02f1b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/87b68208d5c1188808dd7839ee1e6c8ec3b02f1b",
+                "reference": "87b68208d5c1188808dd7839ee1e6c8ec3b02f1b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php80\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ion Bazan",
+                    "email": "ion.bazan@gmail.com"
+                },
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.29.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-01-29T20:11:03+00:00"
+        },
+        {
+            "name": "twig/twig",
+            "version": "v3.9.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/twigphp/Twig.git",
+                "reference": "a842d75fed59cdbcbd3a3ad7fb9eb768fc350d58"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/a842d75fed59cdbcbd3a3ad7fb9eb768fc350d58",
+                "reference": "a842d75fed59cdbcbd3a3ad7fb9eb768fc350d58",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/polyfill-ctype": "^1.8",
+                "symfony/polyfill-mbstring": "^1.3",
+                "symfony/polyfill-php80": "^1.22"
+            },
+            "require-dev": {
+                "psr/container": "^1.0|^2.0",
+                "symfony/phpunit-bridge": "^5.4.9|^6.4|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/Resources/core.php",
+                    "src/Resources/debug.php",
+                    "src/Resources/escaper.php",
+                    "src/Resources/string_loader.php"
+                ],
+                "psr-4": {
+                    "Twig\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com",
+                    "homepage": "http://fabien.potencier.org",
+                    "role": "Lead Developer"
+                },
+                {
+                    "name": "Twig Team",
+                    "role": "Contributors"
+                },
+                {
+                    "name": "Armin Ronacher",
+                    "email": "armin.ronacher@active-4.com",
+                    "role": "Project Founder"
+                }
+            ],
+            "description": "Twig, the flexible, fast, and secure template language for PHP",
+            "homepage": "https://twig.symfony.com",
+            "keywords": [
+                "templating"
+            ],
+            "support": {
+                "issues": "https://github.com/twigphp/Twig/issues",
+                "source": "https://github.com/twigphp/Twig/tree/v3.9.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/twig/twig",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-04-18T11:59:33+00:00"
+        },
+        {
+            "name": "vlucas/phpdotenv",
+            "version": "v5.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/vlucas/phpdotenv.git",
+                "reference": "2cf9fb6054c2bb1d59d1f3817706ecdb9d2934c4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/vlucas/phpdotenv/zipball/2cf9fb6054c2bb1d59d1f3817706ecdb9d2934c4",
+                "reference": "2cf9fb6054c2bb1d59d1f3817706ecdb9d2934c4",
+                "shasum": ""
+            },
+            "require": {
+                "ext-pcre": "*",
+                "graham-campbell/result-type": "^1.1.2",
+                "php": "^7.2.5 || ^8.0",
+                "phpoption/phpoption": "^1.9.2",
+                "symfony/polyfill-ctype": "^1.24",
+                "symfony/polyfill-mbstring": "^1.24",
+                "symfony/polyfill-php80": "^1.24"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.8.2",
+                "ext-filter": "*",
+                "phpunit/phpunit": "^8.5.34 || ^9.6.13 || ^10.4.2"
+            },
+            "suggest": {
+                "ext-filter": "Required to use the boolean validator."
+            },
+            "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": true
+                },
+                "branch-alias": {
+                    "dev-master": "5.6-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Dotenv\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
+                    "name": "Vance Lucas",
+                    "email": "vance@vancelucas.com",
+                    "homepage": "https://github.com/vlucas"
+                }
+            ],
+            "description": "Loads environment variables from `.env` to `getenv()`, `$_ENV` and `$_SERVER` automagically.",
+            "keywords": [
+                "dotenv",
+                "env",
+                "environment"
+            ],
+            "support": {
+                "issues": "https://github.com/vlucas/phpdotenv/issues",
+                "source": "https://github.com/vlucas/phpdotenv/tree/v5.6.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/vlucas/phpdotenv",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-11-12T22:43:29+00:00"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": [],
+    "plugin-api-version": "2.6.0"
+}

--- a/resources/views/app.twig
+++ b/resources/views/app.twig
@@ -1,5 +1,7 @@
-<html>
-    <head></head>
+<html lang="en">
+    <head>
+        <title>{% block title %}{% endblock %}</title>
+    </head>
 
     <body>
         {% block content %}{% endblock %}

--- a/resources/views/layouts/form.twig
+++ b/resources/views/layouts/form.twig
@@ -57,20 +57,20 @@
 		<fieldset>
 			<legend>Your Property</legend>
 			<p>
-				<label for="type" class="required">Property type</label>
+				<label for="property_type" class="required">Property type</label>
 				<span class="checker-wrap">
 					<label class="checker">
-						<input type="radio" value="apartment-flat" name="type" required>
+						<input type="radio" value="apartment-flat" name="property_type" required>
 						<span class="radio"></span>
 						Apartment/Flat
 					</label>
 					<label class="checker">
-						<input type="radio" value="house" name="type" required checked>
+						<input type="radio" value="house" name="property_type" required checked>
 						<span class="radio"></span>
 						House
 					</label>
 					<label class="checker">
-						<input type="radio" value="bungalow" name="type" required>
+						<input type="radio" value="bungalow" name="property_type" required>
 						<span class="radio"></span>
 						Bungalow
 					</label>
@@ -115,20 +115,20 @@
 		<fieldset>
 			<legend>A Few Final Details</legend>
 			<p>
-				<label for="type" class="required">Survey type</label>
+				<label for="survey_type" class="required">Survey type</label>
 				<span class="checker-wrap">
 					<label class="checker">
-						<input type="radio" value="homebuyer" name="type" required>
+						<input type="radio" value="homebuyer" name="survey_type" required>
 						<span class="radio"></span>
 						HomeBuyer Survey
 					</label>
 					<label class="checker">
-						<input type="radio" value="building" name="type" required checked>
+						<input type="radio" value="building" name="survey_type" required checked>
 						<span class="radio"></span>
 						Building Survey
 					</label>
 					<label class="checker">
-						<input type="radio" value="valuation" name="type" required>
+						<input type="radio" value="valuation" name="survey_type" required>
 						<span class="radio"></span>
 						Valuation Survey
 					</label>

--- a/resources/views/layouts/form.twig
+++ b/resources/views/layouts/form.twig
@@ -1,5 +1,7 @@
 {% extends 'app.twig' %}
 
+{% block title %}Search for companies{% endblock %}
+
 {% block content %}
 	<form name="form" method="post">
 		<fieldset>

--- a/resources/views/layouts/form.twig
+++ b/resources/views/layouts/form.twig
@@ -4,6 +4,14 @@
 
 {% block content %}
 	<form name="form" method="post">
+		<p>The following errors prevented us from searching for companies, please fix them and try again:</p>
+		{% if errors %}
+			<ul class="errors">
+				{% for error in errors %}
+					<li>{{ error }}</li>
+				{% endfor %}
+			</ul>
+		{% endif %}
 		<fieldset>
 			<legend>Contact Details</legend>
 			<p>

--- a/resources/views/layouts/form.twig
+++ b/resources/views/layouts/form.twig
@@ -1,145 +1,147 @@
 {% extends 'app.twig' %}
 
-<form name="form" method="post">
-	<fieldset>
-		<legend>Contact Details</legend>
+{% block content %}
+	<form name="form" method="post">
+		<fieldset>
+			<legend>Contact Details</legend>
+			<p>
+				<label for="first_name" class="required">First name</label>
+				<input type="text" name="first_name" id="first_name" required value="Test">
+			</p>
+			<p>
+				<label for="surname">Surname</label>
+				<input type="text" name="surname" id="surname" placeholder="" value="Customer">
+			</p>
+			<p>
+				<label for="email" class="required">Email address</label>
+				<input type="email" name="email" id="email" required value="test@email.com">
+			</p>
+			<p>
+				<label for="phone" class="required">Telephone number</label>
+				<input type="text" name="phone" id="phone" required value="00000111111">
+			</p>
+		</fieldset>
+	​
+		<fieldset>
+			<legend>Address</legend>
+			<p>
+				<label for="address_line_1" class="required">Current address line 1</label>
+				<input type="text" name="address_line_1" id="address_line_1" required value="123 Current St">
+			</p>
+			<p>
+				<label for="address_line_2">Current address line 2</label>
+				<input type="text" name="address_line_2" id="address_line_2">
+			</p>
+			<p>
+				<label for="address_line_3">Current address line 3</label>
+				<input type="text" name="address_line_3" id="address_line_3">
+			</p>
+			<p>
+				<label for="address_line_4">Current address line 4</label>
+				<input type="text" name="address_line_4" id="address_line_4">
+			</p>
+			<p>
+				<label for="town" class="required">Current town/city</label>
+				<input type="text" name="town" id="town" required value="Current Town">
+			</p>
+			<p>
+				<label for="county">Current county</label>
+				<input type="text" name="county" id="county">
+			</p>
+			<p>
+				<label for="postcode" class="required">Current postcode</label>
+				<input type="text" name="postcode" id="postcode" required value="CF11 9HB">
+			</p>
+		</fieldset>
+
+		<fieldset>
+			<legend>Your Property</legend>
+			<p>
+				<label for="type" class="required">Property type</label>
+				<span class="checker-wrap">
+					<label class="checker">
+						<input type="radio" value="apartment-flat" name="type" required>
+						<span class="radio"></span>
+						Apartment/Flat
+					</label>
+					<label class="checker">
+						<input type="radio" value="house" name="type" required checked>
+						<span class="radio"></span>
+						House
+					</label>
+					<label class="checker">
+						<input type="radio" value="bungalow" name="type" required>
+						<span class="radio"></span>
+						Bungalow
+					</label>
+				</span>
+			</p>
+			<p>
+				<label>How many bedrooms?</label>
+				<span class="checker-wrap">
+					<label class="checker">
+						<input type="radio" value="1" name="bedrooms" required>
+						<span class="radio"></span>
+						1 Bedroom
+					</label>
+					<label class="checker">
+						<input type="radio" value="2" name="bedrooms" required>
+						<span class="radio"></span>
+						2 Bedrooms
+					</label>
+					<label class="checker">
+						<input type="radio" value="3" name="bedrooms" required checked>
+						<span class="radio"></span>
+						3 Bedrooms
+					</label>
+					<label class="checker">
+						<input type="radio" value="4" name="bedrooms" required>
+						<span class="radio"></span>
+						4 Bedrooms
+					</label>
+					<label class="checker">
+						<input type="radio" value="5+" name="bedrooms" required>
+						<span class="radio"></span>
+						5 Bedrooms or more
+					</label>
+				</span>
+			</p>
+			<p>
+				<label for="property_value">Property Value</label>
+				<input type="text" id="property_value" name="property_value" required data-min="20000" data-max="10000000" value="150000">
+			</p>
+		</fieldset>
+
+		<fieldset>
+			<legend>A Few Final Details</legend>
+			<p>
+				<label for="type" class="required">Survey type</label>
+				<span class="checker-wrap">
+					<label class="checker">
+						<input type="radio" value="homebuyer" name="type" required>
+						<span class="radio"></span>
+						HomeBuyer Survey
+					</label>
+					<label class="checker">
+						<input type="radio" value="building" name="type" required checked>
+						<span class="radio"></span>
+						Building Survey
+					</label>
+					<label class="checker">
+						<input type="radio" value="valuation" name="type" required>
+						<span class="radio"></span>
+						Valuation Survey
+					</label>
+				</span>
+			</p>
+			<p>
+				<label for="additional_information">Any other information you think we should know?</label>
+				<textarea name="additional_information" id="additional_information" rows="5"></textarea>
+			</p>
+		</fieldset>
+
 		<p>
-			<label for="first_name" class="required">First name</label>
-			<input type="text" name="first_name" id="first_name" required value="Test">
+			<input type="submit" name="compare" value="Compare Now">
 		</p>
-		<p>
-			<label for="surname">Surname</label>
-			<input type="text" name="surname" id="surname" placeholder="" value="Customer">
-		</p>
-		<p>
-			<label for="email" class="required">Email address</label>
-			<input type="email" name="email" id="email" required value="test@email.com">
-		</p>
-		<p>
-			<label for="phone" class="required">Telephone number</label>
-			<input type="text" name="phone" id="phone" required value="00000111111">
-		</p>
-	</fieldset>
-​
-	<fieldset>
-		<legend>Address</legend>
-		<p>
-			<label for="address_line_1" class="required">Current address line 1</label>
-			<input type="text" name="address_line_1" id="address_line_1" required value="123 Current St">
-		</p>
-		<p>
-			<label for="address_line_2">Current address line 2</label>
-			<input type="text" name="address_line_2" id="address_line_2">
-		</p>
-		<p>
-			<label for="address_line_3">Current address line 3</label>
-			<input type="text" name="address_line_3" id="address_line_3">
-		</p>
-		<p>
-			<label for="address_line_4">Current address line 4</label>
-			<input type="text" name="address_line_4" id="address_line_4">
-		</p>
-		<p>
-			<label for="town" class="required">Current town/city</label>
-			<input type="text" name="town" id="town" required value="Current Town">
-		</p>
-		<p>
-			<label for="county">Current county</label>
-			<input type="text" name="county" id="county">
-		</p>
-		<p>
-			<label for="postcode" class="required">Current postcode</label>
-			<input type="text" name="postcode" id="postcode" required value="CF11 9HB">
-		</p>
-	</fieldset>
-	
-	<fieldset>
-		<legend>Your Property</legend>
-		<p>
-			<label for="type" class="required">Property type</label>
-			<span class="checker-wrap">
-				<label class="checker">
-					<input type="radio" value="apartment-flat" name="type" required>
-					<span class="radio"></span>
-					Apartment/Flat
-				</label>
-				<label class="checker">
-					<input type="radio" value="house" name="type" required checked>
-					<span class="radio"></span>
-					House
-				</label>
-				<label class="checker">
-					<input type="radio" value="bungalow" name="type" required>
-					<span class="radio"></span>
-					Bungalow
-				</label>
-			</span>
-		</p>
-		<p>
-			<label>How many bedrooms?</label>
-			<span class="checker-wrap">
-				<label class="checker">
-					<input type="radio" value="1" name="bedrooms" required>
-					<span class="radio"></span>
-					1 Bedroom
-				</label>
-				<label class="checker">
-					<input type="radio" value="2" name="bedrooms" required>
-					<span class="radio"></span>
-					2 Bedrooms
-				</label>
-				<label class="checker">
-					<input type="radio" value="3" name="bedrooms" required checked>
-					<span class="radio"></span>
-					3 Bedrooms
-				</label>
-				<label class="checker">
-					<input type="radio" value="4" name="bedrooms" required>
-					<span class="radio"></span>
-					4 Bedrooms
-				</label>
-				<label class="checker">
-					<input type="radio" value="5+" name="bedrooms" required>
-					<span class="radio"></span>
-					5 Bedrooms or more
-				</label>
-			</span>
-		</p>
-		<p>
-			<label for="property_value">Property Value</label>
-			<input type="text" id="property_value" name="property_value" required data-min="20000" data-max="10000000" value="150000">
-		</p>
-	</fieldset>
-	
-	<fieldset>
-		<legend>A Few Final Details</legend>
-		<p>
-			<label for="type" class="required">Survey type</label>
-			<span class="checker-wrap">
-				<label class="checker">
-					<input type="radio" value="homebuyer" name="type" required>
-					<span class="radio"></span>
-					HomeBuyer Survey
-				</label>
-				<label class="checker">
-					<input type="radio" value="building" name="type" required checked>
-					<span class="radio"></span>
-					Building Survey
-				</label>
-				<label class="checker">
-					<input type="radio" value="valuation" name="type" required>
-					<span class="radio"></span>
-					Valuation Survey
-				</label>
-			</span>
-		</p>
-		<p>
-			<label for="additional_information">Any other information you think we should know?</label>
-			<textarea name="additional_information" id="additional_information" rows="5"></textarea>
-		</p>
-	</fieldset>
-	
-	<p>
-		<input type="submit" name="compare" value="Compare Now">
-	</p>
-</form>
+	</form>
+{% endblock %}

--- a/resources/views/layouts/form.twig
+++ b/resources/views/layouts/form.twig
@@ -102,9 +102,9 @@
 						4 Bedrooms
 					</label>
 					<label class="checker">
-						<input type="radio" value="5+" name="bedrooms" required>
+						<input type="radio" value="5" name="bedrooms" required>
 						<span class="radio"></span>
-						5 Bedrooms or more
+						5 Bedrooms
 					</label>
 				</span>
 			</p>

--- a/resources/views/layouts/results.twig
+++ b/resources/views/layouts/results.twig
@@ -1,21 +1,23 @@
 {% extends 'app.twig' %}
 
-<h1>Results</h1>
+{% block content %}
+    <h1>Results</h1>
 
-<p>You matched with <!-- NUMBER OF COMPANIES MATCHED --> </p>
+    <p>You matched with <!-- NUMBER OF COMPANIES MATCHED --> </p>
 
-<div class="matches">
-    {% for company in matchedCompanies %}
-        <div class="matches__match">
-            <h3>{{ company.name }}</h3>
-            <p>{{ company.description }}</p>
-            <a href="#" class="matches__match__more">more</a>
+    <div class="matches">
+        {% for company in matchedCompanies %}
+            <div class="matches__match">
+                <h3>{{ company.name }}</h3>
+                <p>{{ company.description }}</p>
+                <a href="#" class="matches__match__more">more</a>
 
-            <div class="match__match__details" style="display:none">
-                <p><strong>Email:</strong> {{ company.email }}</p>
-                <p><strong>Phone:</strong> {{ company.phone }}</p>
-                <p><strong>Website:</strong> {{ company.website }}</p>
+                <div class="match__match__details" style="display:none">
+                    <p><strong>Email:</strong> {{ company.email }}</p>
+                    <p><strong>Phone:</strong> {{ company.phone }}</p>
+                    <p><strong>Website:</strong> {{ company.website }}</p>
+                </div>
             </div>
-        </div>
-    {% endfor %}
-</div>
+        {% endfor %}
+    </div>
+{% endblock %}

--- a/resources/views/layouts/results.twig
+++ b/resources/views/layouts/results.twig
@@ -1,5 +1,7 @@
 {% extends 'app.twig' %}
 
+{% block title %}Search results{% endblock %}
+
 {% block content %}
     <h1>Results</h1>
 


### PR DESCRIPTION
## Description of the problem
There are some problems with the newly implement search form that will allow customers to search for companies to carry out surveys, this PR fixes these issues and gets the form working as expected.

## Assumptions
I have made the following assumptions in this PR:
- The maximum number of matches is controller by an environment variable: this is because there was a variable in the example environment file called `MAX_MATCHED_COMPANIES` that was set to `3` - the expected maximum number of returned results.
- The pick method is not needed: looking at the code, it seemed logical to specify the number of matches to find when doing the matching. It reduces the amount of processing that needs to be done in PHP and simplifies the PHP code.
- The search will not be looking companies that survey more than 5 bedrooms. Looking at the way the number of bedrooms companies survey is stored in the database, searching for bedrooms greater than a number would be difficult, limited and not very efficient. It would need a larger separate task to tackle this, so for the time being referenced to greater than 5 were removed.

## Changes in this PR
- Add the composer lock file to ensure that all environments including development and production are using the same versions of dependencies, it is recommended in the [composer documentation](https://getcomposer.org/doc/01-basic-usage.md#commit-your-composer-lock-file-to-version-control).
- Make the form controller extend the base controller to fix the `render` method not existing on the `FormController`.
- Define the parent template blocks that are being over-ridden in the views as described [here in the twig documentation](https://twig.symfony.com/doc/3.x/templates.html#template-inheritance).
- Register the POST route for form submission that calls the `submit` function in the `FormController`.
- Add a function to fetch the max matches from the ENV - storing this in configuration removes the need to create a branch and go through a development process to change the number of items in search results.
- Added a function to fetch the postcode prefix - it felt best to extract this logic into its own function.
- Add the logic to get the match function to find companies that match the search
- Add logic to deduct credits from the matched companies
- Fix passing the results into the results view
- Randomly select matched companies. The approach taken me run into some scaling issues down the line, this should be fine for a while especially considering there are constraints on the results and indexes could be applied to improve this first. Here is some more information about selecting random rows from the database: https://www.basedash.com/blog/random-select-in-mysql
- Fixed some accessibility issues found by a quick accessibility test.
- Change the "5 or more bedrooms" option to 5 - as explained in the assumptions.
- Add some basic form validation - at the moment it does not pre-fill what the user selected but this would be a good user experience improvement we could make in the future.

## Testing instructions
1. Check out this branch.
2. Follow the instructions in the README to get your environment working.
3. Open a web browser and go to your local development URL followed by `/form`.
4. Fill out the form and submit.
5. Check that the responses are expected.
6. Go to the database and check the credits for the returned companies.
7. Refresh the page and resubmit the form prompt.
8. Check the DB to see if the returned results have had their credits decremented.
9. Test around and try to cover the "sad paths".